### PR TITLE
Use HTTPS URLs for Dress to Impress

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func writeExpiryHeaders(w http.ResponseWriter, expiry time.Time,
 }
 
 func redirectToImpress(w http.ResponseWriter, r *http.Request, petName string, impressHost string, destination string) {
-	redirectUrl := "http://" + impressHost + "/pets/load?name=" +
+	redirectUrl := impressHost + "/pets/load?name=" +
 		url.QueryEscape(petName) + "&destination=" + destination
 	http.Redirect(w, r, redirectUrl, http.StatusTemporaryRedirect)
 }
@@ -110,7 +110,8 @@ func serveCustomizationErrorMessage(w http.ResponseWriter, r *http.Request, msg 
 	}
 }
 
-func serveCustomization(w http.ResponseWriter, r *http.Request, cc chan customizationSubmission, petName string, customizationService models.CustomizationService, impressHost string) {
+func serveCustomization(w http.ResponseWriter, r *http.Request, cc chan customizationSubmission, petName string, customizationService models.CustomizationService, 
+			string) {
 	if len(petName) == 0 {
 		serveCustomizationErrorMessage(w, r, "name blank",
 			http.StatusBadRequest, petName)
@@ -123,9 +124,9 @@ func serveCustomization(w http.ResponseWriter, r *http.Request, cc chan customiz
 		// If it's a request to DTI, pass them off to the old embedded AMF pet
 		// loader. Otherwise, yield a JSON error.
 		redirectFormat := r.FormValue("redirect")
-		if redirectFormat == "http://"+impressHost+"/wardrobe#{q}" {
+		if redirectFormat == impressHost+"/wardrobe#{q}" {
 			redirectToImpress(w, r, petName, impressHost, "wardrobe")
-		} else if redirectFormat == "http://"+impressHost+"/#{q}" {
+		} else if redirectFormat == impressHost+"/#{q}" {
 			redirectToImpress(w, r, petName, impressHost, "")
 		} else {
 			serveCustomizationErrorMessage(w, r,
@@ -232,7 +233,7 @@ func submit(impress services.ImpressClient, csc chan customizationSubmission) {
 func main() {
 	port := flag.Int("port", 8888, "port on which to run web server")
 	neopetsHost := flag.String("neopetsGateway", "http://www.neopets.com/amfphp/json.php", "Neopets JSON gateway URL")
-	impressHost := flag.String("impress", "impress.openneo.net", "Dress to Impress host")
+	impressHost := flag.String("impress", "https://impress.openneo.net", "Dress to Impress host")
 	pingIntervalInSeconds := flag.Int("pingInterval", 60, "Ping Neopets for status every X seconds")
 	pingTimeoutInSeconds := flag.Int("pingTimeout", 10, "Give up on the Neopets ping after X seconds")
 	pingUrl := flag.String("pingUrl", "http://www.neopets.com/", "Neopets URL to ping")

--- a/services/impress.go
+++ b/services/impress.go
@@ -13,7 +13,7 @@ type ImpressClient struct {
 }
 
 func NewImpressClient(host string) ImpressClient {
-	return ImpressClient{submitURL: fmt.Sprintf("http://%s/pets/submit.json", host)}
+	return ImpressClient{submitURL: fmt.Sprintf("%s/pets/submit.json", host)}
 }
 
 func (impress ImpressClient) Submit(c models.Customization, userId int) (*http.Response, error) {


### PR DESCRIPTION
Whoops, we broke modeling when we switched to HTTPS!

Specifically, my hypothesis is that our internal requests that submit pet data to Dress to Impress aren't working, because the request attempts to redirect from `http://impress.openneo.net/` to `https://impress.openneo.net/`, and the client doesn't follow redirects?

In this change, we update the scheme of the host to be a configurable part of the string, and default to HTTPS.